### PR TITLE
Update get_models.sh to only delete zips on success

### DIFF
--- a/model-weights/get_models.sh
+++ b/model-weights/get_models.sh
@@ -17,10 +17,7 @@ wget --load-cookies /tmp/cookies.txt -r "https://docs.google.com/uc?export=downl
 wget --load-cookies /tmp/cookies.txt -r "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1a_pbXPYNj7_Gi6OxUqNo_T23Dt_9CzOV' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1a_pbXPYNj7_Gi6OxUqNo_T23Dt_9CzOV" -O $H5_FILENAME && rm -rf /tmp/cookies.txt
 
 # Unzip
-unzip -q $W_FILENAME
-unzip -q $H5_FILENAME
-
-# Delete .zip files
-rm -rf $W_FILENAME $H5_FILENAME
+unzip -q $W_FILENAME && rm -rf $W_FILENAME
+unzip -q $H5_FILENAME && rm -rf $H5_FILENAME
 
 echo "*** All done!!!"


### PR DESCRIPTION
I had an issue where the zips would get deleted although the `unzip` command had failed, this caused me to download the weights multiple times.
I edited the script so that it would only delete the files IFF the unzip is successful.

This should help reducing bandwidth too